### PR TITLE
fixed checkpointing interval

### DIFF
--- a/train.py
+++ b/train.py
@@ -243,7 +243,7 @@ def train(rank, world_size, args):
                     )
 
                 new_best = best_loss > validation_loss.value
-                if new_best or global_step % CHECKPOINT_INTERVAL:
+                if new_best or global_step % CHECKPOINT_INTERVAL == 0:
                     if new_best:
                         logger.info("-------- new best model found!")
                         best_loss = validation_loss.value


### PR DESCRIPTION
Hello! I've found bug with checkpointing in your code which leads to that only best checkpoints is getting saved. This happens because if CHECKPOINT_INTERVAL = VALIDATION_INTERVAL (default case), then `if global_step % VALIDATION_INTERVAL  == 0 and if global_step % CHECKPOINT_INTERVAL` never evaluates to True.
This pull request fixes this.